### PR TITLE
Add a definition for `table.empty` to the MohoLua environment

### DIFF
--- a/Utilities/File.lua
+++ b/Utilities/File.lua
@@ -79,6 +79,10 @@ local Sandboxes = {
                 return env
             end
         end
+        env.table.empty = function(t)
+            if type(t) ~= 'table' then return true end
+            return next(t) == nil
+        end
         return env
     end,
     Blueprint = function()


### PR DESCRIPTION
This function is widely used in the FAF environment.